### PR TITLE
Add clipboard fix and improved prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The app is designed for simplicity, with a clean UI inspired by modern voice rec
 * Edit or correct transcribed text in the main window.
 * Optional translation to selected language
 * Save transcripts as plain text files.
+* Copy transcripts to your clipboard with a single click.
 * Simple configuration using `.env` or environment variables for the OpenAI API key.
 
 ## Installation


### PR DESCRIPTION
## Summary
- load Gdk for clipboard usage
- clarify prompts for paragraph formatting
- set clipboard content via Gdk.ContentProvider

## Testing
- `python -m py_compile dictaite/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_683b5955d800832e8e357baa9356fd13